### PR TITLE
accommodate h5ToGrids to multiple solvate

### DIFF
--- a/grid/grid.py
+++ b/grid/grid.py
@@ -383,7 +383,7 @@ gridlist[speciesindex]["distributiontype"] = GridObject
     deltas = [h5file.root.parameters_uv.grid_spacing.read()]*3
     origin = [-deltas[dim]*gridcounts[dim]*0.5+offset[dim] for dim in range(3)]
 
-    speciesnames = h5file.root.data_vv.parameters_vv.solvent.element_0.names[:]
+    speciesnames = [a for x in h5file.root.data_vv.parameters_vv.solvent for a in x.names]
     grids = dict((speciesname, {}) for speciesname in speciesnames)
     for key, value in h5file.root._v_children.iteritems():
         # 


### PR DESCRIPTION
Dan

I have changed a line in h5ToGrids on grid.py to accommodate multiple solvent.
This change have been passed a grid_tests.py.
I also confirm that this change correctly work on gridconvert.py by directry change the code on sequoia.

Sugita
